### PR TITLE
feat/#161 JiYoungQA

### DIFF
--- a/src/@components/@common/hooks/useOutClickCloser.ts
+++ b/src/@components/@common/hooks/useOutClickCloser.ts
@@ -1,17 +1,18 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface UseOutClickCloserProps {
-  ref: React.MutableRefObject<HTMLDivElement | null>;
   handleOutClickCloser: () => void;
 }
 
 export default function useOutClickCloser(props: UseOutClickCloserProps) {
-  const { ref, handleOutClickCloser } = props;
+  const { handleOutClickCloser } = props;
+
+  const currentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent | TouchEvent) => {
       if (!(e.target instanceof HTMLElement)) return;
-      if (ref.current && !ref.current.contains(e.target)) {
+      if (currentRef.current && !currentRef.current.contains(e.target)) {
         handleOutClickCloser();
       }
     };
@@ -23,5 +24,7 @@ export default function useOutClickCloser(props: UseOutClickCloserProps) {
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("touchstart", handleClickOutside);
     };
-  }, [ref, handleOutClickCloser]);
+  }, [currentRef, handleOutClickCloser]);
+
+  return currentRef;
 }

--- a/src/@components/@common/hooks/useOutClickCloser.ts
+++ b/src/@components/@common/hooks/useOutClickCloser.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+
+interface UseOutClickCloserProps {
+  ref: React.MutableRefObject<HTMLDivElement | null>;
+  handleOutClickCloser: () => void;
+}
+
+export default function useOutClickCloser(props: UseOutClickCloserProps) {
+  const { ref, handleOutClickCloser } = props;
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent | TouchEvent) => {
+      if (!(e.target instanceof HTMLElement)) return;
+      if (ref.current && !ref.current.contains(e.target)) {
+        handleOutClickCloser();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+    };
+  }, [ref, handleOutClickCloser]);
+}

--- a/src/@components/JoinPage/AgreePage/index.tsx
+++ b/src/@components/JoinPage/AgreePage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 
 import { IcEmptyCheckBox, IcFullCheckBox, IcNextBtn } from "../../../asset/icon";
@@ -22,9 +22,7 @@ export default function AgreePage() {
   const [isPickedItems, setIsPickedItems] = useState<boolean[]>([false, false, false, false, false]);
   const [isOpenAlert, setIsOpenAlert] = useState(false);
 
-  const alertElement = useRef<HTMLDivElement | null>(null);
-  useOutClickCloser({
-    ref: alertElement,
+  const alertElement = useOutClickCloser({
     handleOutClickCloser: () => {
       setIsOpenAlert(false);
     },

--- a/src/@components/JoinPage/AgreePage/index.tsx
+++ b/src/@components/JoinPage/AgreePage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { MouseEvent, useEffect, useRef, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 
 import { IcEmptyCheckBox, IcFullCheckBox, IcNextBtn } from "../../../asset/icon";
@@ -20,6 +20,7 @@ export default function AgreePage() {
 
   const [isPickedItems, setIsPickedItems] = useState<boolean[]>([false, false, false, false, false]);
   const [isOpenAlert, setIsOpenAlert] = useState(false);
+  const alertElement = useRef<HTMLDivElement | null>(null);
 
   function handleChecking(index: number) {
     switch (index) {
@@ -78,6 +79,19 @@ export default function AgreePage() {
 
     return flag;
   };
+  useEffect(() => {
+    const clickOutside = (e: any) => {
+      if (isOpenAlert && alertElement.current && !alertElement.current.contains(e.target as HTMLElement)) {
+        setIsOpenAlert(false);
+      }
+    };
+
+    document.addEventListener("mousedown", clickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", clickOutside);
+    };
+  }, [isOpenAlert]);
 
   const agreeLists = agreeListsContents.map((item, index) => (
     <St.AgreeContentItem key={`condition-${index}`} isActive={isPickedItems[index]}>
@@ -100,12 +114,14 @@ export default function AgreePage() {
 
   return (
     <St.Root>
-      <Header prevPage={prevPages[5].prevPage} />
+      <Header prevPage={prevPages[4].prevPage} />
       <PageProgressBar rate={progressRate[4].rate} />
       <St.JoinAgree>
         <St.AgreeTitle>약관을 동의해주세요</St.AgreeTitle>
         <St.AgreeContent>{agreeLists}</St.AgreeContent>
-        <ModalContainerWithAnimation isopen={isOpenAlert}>필수 항목에 동의해주세요</ModalContainerWithAnimation>
+        <ModalContainerWithAnimation isopen={isOpenAlert} ref={alertElement}>
+          필수 항목에 동의해주세요
+        </ModalContainerWithAnimation>
         <St.JoinButton onClick={completeJoinBtn}>회원가입 완료하기</St.JoinButton>
       </St.JoinAgree>
       <Footer />

--- a/src/@components/JoinPage/AgreePage/index.tsx
+++ b/src/@components/JoinPage/AgreePage/index.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 
 import { IcEmptyCheckBox, IcFullCheckBox, IcNextBtn } from "../../../asset/icon";
@@ -8,6 +8,7 @@ import { prevPages } from "../../../core/join/prevPages";
 import { progressRate } from "../../../core/join/progressRate";
 import { routePaths } from "../../../core/routes/path";
 import Footer from "../../@common/Footer";
+import useOutClickCloser from "../../@common/hooks/useOutClickCloser";
 import { UserInfoFormDataContext } from "..";
 import Header from "../common/Header";
 import PageProgressBar from "../common/PageProgressBar";
@@ -20,7 +21,14 @@ export default function AgreePage() {
 
   const [isPickedItems, setIsPickedItems] = useState<boolean[]>([false, false, false, false, false]);
   const [isOpenAlert, setIsOpenAlert] = useState(false);
+
   const alertElement = useRef<HTMLDivElement | null>(null);
+  useOutClickCloser({
+    ref: alertElement,
+    handleOutClickCloser: () => {
+      setIsOpenAlert(false);
+    },
+  });
 
   function handleChecking(index: number) {
     switch (index) {
@@ -79,19 +87,6 @@ export default function AgreePage() {
 
     return flag;
   };
-  useEffect(() => {
-    const clickOutside = (e: any) => {
-      if (isOpenAlert && alertElement.current && !alertElement.current.contains(e.target as HTMLElement)) {
-        setIsOpenAlert(false);
-      }
-    };
-
-    document.addEventListener("mousedown", clickOutside);
-
-    return () => {
-      document.removeEventListener("mousedown", clickOutside);
-    };
-  }, [isOpenAlert]);
 
   const agreeLists = agreeListsContents.map((item, index) => (
     <St.AgreeContentItem key={`condition-${index}`} isActive={isPickedItems[index]}>

--- a/src/@components/JoinPage/UserProfilePage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/index.tsx
@@ -60,7 +60,7 @@ export default function UserProfilePage() {
 
   return (
     <St.Root>
-      <Header prevPage={prevPages[4].prevPage} />
+      <Header prevPage={prevPages[3].prevPage} />
       <PageProgressBar rate={progressRate[3].rate} />
       <St.ProfileContainer>
         <St.Title>프로필을 설정해주세요</St.Title>

--- a/src/core/api/common/constants.ts
+++ b/src/core/api/common/constants.ts
@@ -3,7 +3,7 @@ export const PATH = {
   CATEGORIES_CARDS: "/cards",
   USERS_: "/users",
   USERS_EMAIL: "/email-verification",
-  USERS_BOOKMARK: "/bookmark",
+  USERS_BOOKMARK: "/bookmarks",
   USERS_LOGIN: "/login",
   USERS_PROFILEIMAGE: "/profile-image",
   USERS_NICKNAME: "/nickname",

--- a/src/core/join/prevPages.ts
+++ b/src/core/join/prevPages.ts
@@ -14,7 +14,7 @@ export const prevPages: PrevPages[] = [
     prevPage: `${routePaths.Join_}${routePaths.Join_EmailConfirm}`,
   },
   {
-    prevPage: "/userinfo",
+    prevPage: `${routePaths.Join_}${routePaths.Join_UserInfo}`,
   },
   {
     prevPage: `${routePaths.Join_}${routePaths.Join_UserProfile}`,


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [ ] 브랜치명, 브랜치 알맞게 설정
- [ ] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [ ] PR이 승인된 경우 해당 브랜치는 삭제하기

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
- 하트 누르면 마이피클로 안가는거 api 경로수정했습니다! ( 제가 전에 api경로들 상수로 바꾸는 과정에서 실수했었더라굽쇼 ㅎㅅㅎ)
- userProfile 페이지에서 뒤로가기 하는거 했습니다!
✅ 업데이트 ✅
약관동의부분에서 필수된거 체크안했을 때 얼럿창을 띄으고, 빈공간을 클릭했을 때 얼럿창 내리는거 했습니당


<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자ㅑ (기록하면서 개발하기!) -->
 💙 다같이 알면 좋을 것 같아서💙
 얼럿창 외부의 이벤트를 감지할 때 왜 click이 아니라 mousedown을 썼나?
 --> 지금 `회원가입 완료하기` 버튼에 click 이벤트를 사용해서 얼럿창이 열리도록 구현이 되어있는데, 
 document에 click 이벤트로 닫는것을 구현한다면 이벤트 버블링에 의해서
 완료버튼 click 이벤트 실행 -> 부모요소 타고타고 올라가다가 -> document에 click이벤트 실행 -> isOpenAlert가 true가 됐다가 false로 바껴버림 -> 얼럿창이 안뜸
 요렇게 돼서 이벤트를 다르게 써줘야 한다고함미다~! 

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 🚨 ㄹㅇ 삐뽀삐뽀 🚨
아래같이 mousedown 이벤트를 이용해서 얼럿창 외부의 이벤트를 감지하고, callback 함수로 얼럿창 상태를 바꾸는 함수를 넣어줬는데,
이벤트의 타입으로 뭘!!!!!!!로 싹!!!!!다 해보고 이리저리 로직을 바꿔봐도 콜백함수를 호출하는 부분에서 "일치하는 오버로드가 없다"고 떠서 일단 any를 박아뒀슴미다.... 증말 모르겠어욤 어떻게 해야되는지...
일단 돌아는 감미다!! 머지 하더라도 계속 시도해서 고쳐놓을께요!!!!🥺
![스크린샷 2022-09-22 오전 3 24 00](https://user-images.githubusercontent.com/87578512/191583921-fbe86b16-7b59-47a3-a6e5-60933c3f2289.png)

<br />


## 📸 스크린샷
<!--작업한 내용에서 UI 변화가 있다면 스크린샷을 첨부해주세요-->
<!--이미지 업로드(복붙) 후 src="(링크)" 형태로 넣어조요-->
<img src="" width=80% />