### PR TITLE
Feat/#189 vote cta btn

### DIFF
--- a/src/@components/VotePage/VoteContent/index.tsx
+++ b/src/@components/VotePage/VoteContent/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import useBallotTopic from "../../../core/api/vote";
 import { routePaths } from "../../../core/routes/path";
@@ -12,6 +12,7 @@ export default function VoteContent() {
   const params = useParams();
   const [voteId, setVoteId] = useState(`${params.voteId}`);
   const { ballotTopic, isBeforeVotingState, mutateBallotState } = useBallotTopic(voteId);
+  const navigate = useNavigate();
 
   if (!ballotTopic) return <Loading backgroundColor="white" />;
 
@@ -28,18 +29,19 @@ export default function VoteContent() {
 
       <St.BtnContainer>
         {ballotTopic.data.beforeTopicId ? (
-          <St.MoveBtn beforeId={true} onClick={() => setVoteId(`${ballotTopic.data.beforeTopicId}`)}>
-            이전 질문
-          </St.MoveBtn>
+          <St.BeforeBtn onClick={() => setVoteId(`${ballotTopic.data.beforeTopicId}`)}>이전 질문</St.BeforeBtn>
         ) : (
           <St.NoLinkBtn>이전 질문</St.NoLinkBtn>
         )}
         {ballotTopic.data.nextTopicId ? (
-          <St.MoveBtn beforeId={false} onClick={() => setVoteId(`${ballotTopic.data.nextTopicId}`)}>
-            다음 질문
-          </St.MoveBtn>
+          <St.MoveBtn onClick={() => setVoteId(`${ballotTopic.data.nextTopicId}`)}>다음 질문</St.MoveBtn>
         ) : (
-          <St.LinkBtn to={routePaths.Main}>홈으로</St.LinkBtn>
+          <St.MoveBtn
+            onClick={() => {
+              navigate(routePaths.Main);
+            }}>
+            홈으로
+          </St.MoveBtn>
         )}
       </St.BtnContainer>
     </>

--- a/src/@components/VotePage/VoteContent/index.tsx
+++ b/src/@components/VotePage/VoteContent/index.tsx
@@ -28,12 +28,16 @@ export default function VoteContent() {
 
       <St.BtnContainer>
         {ballotTopic.data.beforeTopicId ? (
-          <St.MoveBtn onClick={() => setVoteId(`${ballotTopic.data.beforeTopicId}`)}>이전 질문</St.MoveBtn>
+          <St.MoveBtn beforeId={true} onClick={() => setVoteId(`${ballotTopic.data.beforeTopicId}`)}>
+            이전 질문
+          </St.MoveBtn>
         ) : (
           <St.NoLinkBtn>이전 질문</St.NoLinkBtn>
         )}
         {ballotTopic.data.nextTopicId ? (
-          <St.MoveBtn onClick={() => setVoteId(`${ballotTopic.data.nextTopicId}`)}>다음 질문</St.MoveBtn>
+          <St.MoveBtn beforeId={false} onClick={() => setVoteId(`${ballotTopic.data.nextTopicId}`)}>
+            다음 질문
+          </St.MoveBtn>
         ) : (
           <St.LinkBtn to={routePaths.Main}>홈으로</St.LinkBtn>
         )}

--- a/src/@components/VotePage/VoteContent/style.ts
+++ b/src/@components/VotePage/VoteContent/style.ts
@@ -16,11 +16,13 @@ const VoteContentTitle = styled.h2`
 const BtnContainer = styled.div`
   position: fixed;
   bottom: 0;
-  left: 0;
-  right: 0;
 
   display: flex;
   gap: 0.1rem;
+
+  ${({ theme }) => theme.media.desktop`
+    width: 36rem;
+  `};
 `;
 
 const MoveBtn = styled.button`

--- a/src/@components/VotePage/VoteContent/style.ts
+++ b/src/@components/VotePage/VoteContent/style.ts
@@ -16,6 +16,7 @@ const VoteContentTitle = styled.h2`
 const BtnContainer = styled.div`
   position: fixed;
   bottom: 0;
+  width: 100%;
 
   display: flex;
   gap: 0.1rem;

--- a/src/@components/VotePage/VoteContent/style.ts
+++ b/src/@components/VotePage/VoteContent/style.ts
@@ -46,6 +46,7 @@ const LinkBtn = styled(Link)`
   align-items: center;
 
   width: 100%;
+  height: 5.8rem;
 
   ${({ theme }) => theme.newFonts.btn1}
 

--- a/src/@components/VotePage/VoteContent/style.ts
+++ b/src/@components/VotePage/VoteContent/style.ts
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import styled from "styled-components";
 
 const VoteContentContainer = styled.article`
@@ -25,22 +24,7 @@ const BtnContainer = styled.div`
   `};
 `;
 
-const MoveBtn = styled.button<{ beforeId: boolean }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: 100%;
-  height: 5.8rem;
-
-  ${({ theme }) => theme.newFonts.btn1}
-
-  border-right: 0.1rem solid ${({ theme, beforeId }) => (beforeId ? theme.colors.white : theme.colors.gray900)};
-  background-color: ${({ theme }) => theme.colors.gray900};
-  color: ${({ theme }) => theme.colors.white};
-`;
-
-const LinkBtn = styled(Link)`
+const MoveBtn = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -54,18 +38,11 @@ const LinkBtn = styled(Link)`
   color: ${({ theme }) => theme.colors.white};
 `;
 
-const NoLinkBtn = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
+const BeforeBtn = styled(MoveBtn)`
+  border-right: 0.1rem solid ${({ theme }) => theme.colors.white};
+`;
 
-  width: 100%;
-  height: 5.8rem;
-
-  ${({ theme }) => theme.newFonts.btn1}
-
-  border-right: 0.1rem solid white;
-  background-color: ${({ theme }) => theme.colors.gray900};
+const NoLinkBtn = styled(BeforeBtn)`
   color: ${({ theme }) => theme.colors.gray600};
 `;
 
@@ -74,7 +51,7 @@ const St = {
   VoteContentTitle,
   BtnContainer,
   MoveBtn,
-  LinkBtn,
+  BeforeBtn,
   NoLinkBtn,
 };
 

--- a/src/@components/VotePage/VoteContent/style.ts
+++ b/src/@components/VotePage/VoteContent/style.ts
@@ -19,14 +19,13 @@ const BtnContainer = styled.div`
   width: 100%;
 
   display: flex;
-  gap: 0.1rem;
 
   ${({ theme }) => theme.media.desktop`
     width: 36rem;
   `};
 `;
 
-const MoveBtn = styled.button`
+const MoveBtn = styled.button<{ beforeId: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -36,6 +35,7 @@ const MoveBtn = styled.button`
 
   ${({ theme }) => theme.newFonts.btn1}
 
+  border-right: 0.1rem solid ${({ theme, beforeId }) => (beforeId ? theme.colors.white : theme.colors.gray900)};
   background-color: ${({ theme }) => theme.colors.gray900};
   color: ${({ theme }) => theme.colors.white};
 `;
@@ -46,7 +46,6 @@ const LinkBtn = styled(Link)`
   align-items: center;
 
   width: 100%;
-  height: 5.8rem;
 
   ${({ theme }) => theme.newFonts.btn1}
 
@@ -64,6 +63,7 @@ const NoLinkBtn = styled.div`
 
   ${({ theme }) => theme.newFonts.btn1}
 
+  border-right: 0.1rem solid white;
   background-color: ${({ theme }) => theme.colors.gray900};
   color: ${({ theme }) => theme.colors.gray600};
 `;


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [x] 브랜치명, 브랜치 알맞게 설정
- [x] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [ ] PR이 승인된 경우 해당 브랜치는 삭제하기

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
- votePage의 CTA 버튼을 서비스 화면에 맞게 조절합니다.
- votePage CTA 버튼의 구분선이 스크롤링에 따라 움직이지 않도록 고정시킵니다.



<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 버튼이 `MoveBtn`으로 통일되어 있길래, props로 `beforeId={true/false}`로 구분지어서 스타일을 적용했습니당!
이전버튼과 다음버튼 두개의 태그로 나눠서 스타일링 하는 것보다 깔끔할 것 같아서 props를 썼는데 
어떠한 방식이 더 좋다~이런게 있을까요?-?

<br />

## 📸 스크린샷
<!--작업한 내용에서 UI 변화가 있다면 스크린샷을 첨부해주세요-->
<!--이미지 업로드(복붙) 후 src="(링크)" 형태로 넣어조요-->
<img src="https://user-images.githubusercontent.com/71490862/216148921-f8f65527-c67b-4cff-9843-8f8987c10947.png" width=40% />