### PR TITLE
Fix/#215 keep join infos

### DIFF
--- a/src/@components/JoinPage/AgreePage/index.tsx
+++ b/src/@components/JoinPage/AgreePage/index.tsx
@@ -1,3 +1,4 @@
+import axios from "axios";
 import React, { useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 
@@ -14,7 +15,7 @@ import { UserInfoFormDataContext } from "..";
 import { ModalContainerWithAnimation, St } from "./style";
 
 export default function AgreePage() {
-  const { userInfoFormData } = useOutletContext<UserInfoFormDataContext>();
+  const { userInfoFormDataForPost } = useOutletContext<UserInfoFormDataContext>();
 
   const navigate = useNavigate();
 
@@ -22,7 +23,7 @@ export default function AgreePage() {
     setIsOpenAlert(false);
   });
 
-  const [isPickedItems, setIsPickedItems] = useState<boolean[]>([false, false, false, false, false]);
+  const [isPickedItems, setIsPickedItems] = useState<boolean[]>([false, true, true, true, false]);
   const [isOpenAlert, setIsOpenAlert] = useState(false);
 
   function handleChecking(index: number) {
@@ -57,12 +58,18 @@ export default function AgreePage() {
     return _items;
   };
 
-  const completeJoinBtn = () => {
-    if (checkIsOkayToPass()) {
-      joinApi.postJoin(userInfoFormData);
-      navigate(routePaths.Login);
-    } else {
-      setIsOpenAlert(true);
+  const completeJoinBtn = async () => {
+    try {
+      if (checkIsOkayToPass()) {
+        await joinApi.postJoin(userInfoFormDataForPost);
+        navigate(routePaths.Login);
+      } else {
+        setIsOpenAlert(true);
+      }
+    } catch (error) {
+      if (!axios.isAxiosError(error)) return;
+
+      alert("회원가입을 다시 시도해주세요.");
     }
   };
 

--- a/src/@components/JoinPage/UserInfoPage/hooks/useEmail.ts
+++ b/src/@components/JoinPage/UserInfoPage/hooks/useEmail.ts
@@ -6,8 +6,8 @@ import { EmailInvalidMessage, emailInvalidMessage } from "../../../../core/join/
 import checkEmailInvalid from "../../../../util/checkInvalidEmail";
 import { useDebounce } from "../../../@common/hooks/useDebounce";
 
-export default function useEmail() {
-  const { query, setQuery, debouncedQuery } = useDebounce("");
+export default function useEmail(defaultFormDataEmailValue: string) {
+  const { query, setQuery, debouncedQuery } = useDebounce(defaultFormDataEmailValue);
 
   const [emailInvalidType, setEmailInvalidType] = useState<EmailInvalidMessage>(emailInvalidMessage.NULL);
 

--- a/src/@components/JoinPage/UserInfoPage/hooks/usePasswords.ts
+++ b/src/@components/JoinPage/UserInfoPage/hooks/usePasswords.ts
@@ -9,13 +9,17 @@ import {
 import checkPasswordInvalid from "../../../../util/checkInvalidPassword";
 import { useDebounce } from "../../../@common/hooks/useDebounce";
 
-export default function usePasswords() {
-  const { query: pwQuery, setQuery: setPwQuery, debouncedQuery: debouncedPwQuery } = useDebounce("");
+export default function usePasswords(defaultFormDataPasswordValue: string) {
+  const {
+    query: pwQuery,
+    setQuery: setPwQuery,
+    debouncedQuery: debouncedPwQuery,
+  } = useDebounce(defaultFormDataPasswordValue);
   const {
     query: pwConfirmQuery,
     setQuery: setPwConfirmQuery,
     debouncedQuery: debouncedPwConfirmQuery,
-  } = useDebounce("");
+  } = useDebounce(defaultFormDataPasswordValue);
 
   const [pwInvalidType, setPwInvalidType] = useState<PasswordInvalidMessage>(passwordInvalidMessage.NULL);
   const [pwConfirmInvalidType, setPwConfirmInvalidType] = useState<PasswordConfirmInvalidMessage>(

--- a/src/@components/JoinPage/UserInfoPage/index.tsx
+++ b/src/@components/JoinPage/UserInfoPage/index.tsx
@@ -1,5 +1,6 @@
 import { useNavigate, useOutletContext } from "react-router-dom";
 
+import { JOIN_FORM_DATA_KEY } from "../../../core/join/formData";
 import { subHeaderInfo } from "../../../core/join/subHeaderInfo";
 import {
   emailInvalidMessage,
@@ -26,8 +27,14 @@ export default function UserInfo() {
   // const { search } = useLocation();
   // const userEmail = new URLSearchParams(search).get("email") as string;
   const navigate = useNavigate();
-  const { setUserInfoFormData } = useOutletContext<UserInfoFormDataContext>();
-  const { query: emailQuery, handleChangeEmailInputValue, emailInvalidType, alertEmptyEmailInputValue } = useEmail();
+  const { formDataEmailValue, formDataPasswordValue, setUserInfoFormData } =
+    useOutletContext<UserInfoFormDataContext>();
+  const {
+    query: emailQuery,
+    handleChangeEmailInputValue,
+    emailInvalidType,
+    alertEmptyEmailInputValue,
+  } = useEmail(formDataEmailValue);
   const {
     pwQuery,
     handleChangePwInputValue,
@@ -37,7 +44,7 @@ export default function UserInfo() {
     handleChangePwConfirmInputValue,
     pwConfirmInvalidType,
     alertEmptyPwConfirmInputValue,
-  } = usePasswords();
+  } = usePasswords(formDataPasswordValue);
 
   const onClickSuccessBtn = () => {
     if (
@@ -50,8 +57,8 @@ export default function UserInfo() {
       setUserInfoFormData(() => {
         const currentFormData = new FormData();
         // currentFormData.append("email", userEmail);
-        currentFormData.append("email", emailQuery);
-        currentFormData.append("password", pwConfirmQuery);
+        currentFormData.append(JOIN_FORM_DATA_KEY.Email, emailQuery);
+        currentFormData.append(JOIN_FORM_DATA_KEY.Password, pwConfirmQuery);
 
         return currentFormData;
       });

--- a/src/@components/JoinPage/UserProfilePage/ProfileBirth/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileBirth/index.tsx
@@ -2,17 +2,18 @@ import { useState } from "react";
 import DatePicker from "react-mobile-datepicker";
 
 import { IcDownArrow } from "../../../../asset/icon";
+import { JOIN_ERROR_KEY } from "../../../../core/join/userProfileErrorMessage";
 import { St } from "./style";
 
 interface ProfileBirthProps {
   birthData: string;
   isInComplete: boolean;
   setBirthData: (birthDay: string) => void;
-  errorMsg: (err: string) => void;
+  handleErrorMsg: (err: string) => void;
 }
 
 export default function ProfileBirth(props: ProfileBirthProps) {
-  const { birthData, isInComplete, setBirthData, errorMsg } = props;
+  const { birthData, isInComplete, setBirthData, handleErrorMsg } = props;
   const [isOpen, setIsOpen] = useState(false);
   const time = new Date();
 
@@ -27,13 +28,13 @@ export default function ProfileBirth(props: ProfileBirthProps) {
     time.getMonth() + 1 <= month && time.getDate() <= day ? age-- : null;
 
     if (year === time.getFullYear() && monthResult >= time.getMonth() + 1 && day >= time.getDate()) {
-      errorMsg("birthValid");
+      handleErrorMsg(JOIN_ERROR_KEY.birth.valid);
     } else if (year > time.getFullYear()) {
-      errorMsg("birthValid");
+      handleErrorMsg(JOIN_ERROR_KEY.birth.valid);
     } else if (age < 14) {
-      errorMsg("birthCheck");
+      handleErrorMsg(JOIN_ERROR_KEY.birth.check);
     } else {
-      errorMsg("");
+      handleErrorMsg(JOIN_ERROR_KEY.Okay);
     }
     return year + "년 " + monthResult + "월 " + dayResult + "일";
   };

--- a/src/@components/JoinPage/UserProfilePage/ProfileBirth/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileBirth/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import DatePicker from "react-mobile-datepicker";
 
 import { IcDownArrow } from "../../../../asset/icon";
-import { JOIN_ERROR_KEY } from "../../../../core/join/userProfileErrorMessage";
+import { JOIN_PROFILE_ALERT_KEY } from "../../../../core/join/userProfileErrorMessage";
 import { St } from "./style";
 
 interface ProfileBirthProps {
@@ -28,13 +28,13 @@ export default function ProfileBirth(props: ProfileBirthProps) {
     time.getMonth() + 1 <= month && time.getDate() <= day ? age-- : null;
 
     if (year === time.getFullYear() && monthResult >= time.getMonth() + 1 && day >= time.getDate()) {
-      handleErrorMsg(JOIN_ERROR_KEY.birth.valid);
+      handleErrorMsg(JOIN_PROFILE_ALERT_KEY.birth.valid);
     } else if (year > time.getFullYear()) {
-      handleErrorMsg(JOIN_ERROR_KEY.birth.valid);
+      handleErrorMsg(JOIN_PROFILE_ALERT_KEY.birth.valid);
     } else if (age < 14) {
-      handleErrorMsg(JOIN_ERROR_KEY.birth.check);
+      handleErrorMsg(JOIN_PROFILE_ALERT_KEY.birth.check);
     } else {
-      handleErrorMsg(JOIN_ERROR_KEY.Okay);
+      handleErrorMsg(JOIN_PROFILE_ALERT_KEY.Okay);
     }
     return year + "년 " + monthResult + "월 " + dayResult + "일";
   };

--- a/src/@components/JoinPage/UserProfilePage/ProfileGender/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileGender/index.tsx
@@ -15,7 +15,7 @@ export default function ProfileJender(props: ProfileJenderProps) {
   return (
     <St.ProfileGender>
       <St.GenderInputForm onChange={handleSelect} value={gender}>
-        <St.Option value="" disabled selected hidden>
+        <St.Option value="" disabled hidden>
           성별을 선택해주세요
         </St.Option>
         <St.Option value="남">남자</St.Option>

--- a/src/@components/JoinPage/UserProfilePage/ProfileGender/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileGender/index.tsx
@@ -1,20 +1,20 @@
 import { St } from "./style";
 
 interface ProfileJenderProps {
-  isSelected: string;
-  setIsSelected: (jender: string) => void;
+  gender: string;
+  setGender: (jender: string) => void;
 }
 
 export default function ProfileJender(props: ProfileJenderProps) {
-  const { isSelected, setIsSelected } = props;
+  const { gender, setGender } = props;
 
   const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setIsSelected(e.target.value);
+    setGender(e.target.value);
   };
 
   return (
     <St.ProfileGender>
-      <St.GenderInputForm onChange={handleSelect} value={isSelected}>
+      <St.GenderInputForm onChange={handleSelect} value={gender}>
         <St.Option value="" disabled selected hidden>
           성별을 선택해주세요
         </St.Option>

--- a/src/@components/JoinPage/UserProfilePage/ProfileImage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileImage/index.tsx
@@ -32,7 +32,7 @@ export default function ProfileImage(props: ProfileImageProps) {
     <St.ProfileImage>
       <St.ImageContainer>
         <St.ImageWrapper>
-          <St.AddImage src={previewImgUrl ? previewImgUrl : ImgDefaultBigProfile} alt="프로필" />
+          <St.AddImage src={previewImgUrl === "" ? ImgDefaultBigProfile : previewImgUrl} alt="프로필" />
         </St.ImageWrapper>
         <St.AddBtnWrapper>
           <IcAddProfileBtn />

--- a/src/@components/JoinPage/UserProfilePage/ProfileImage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileImage/index.tsx
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useOutletContext } from "react-router-dom";
 
 import { IcAddProfileBtn } from "../../../../asset/icon";
 import { ImgDefaultBigProfile } from "../../../../asset/image";
 import compressImage from "../../../../util/imageCompressor";
+import { UserInfoFormDataContext } from "../..";
 import { St } from "./style";
 
 interface ProfileImageProps {
@@ -13,7 +15,15 @@ const MAX_IMAGE_SIZE = 80 * 2;
 
 export default function ProfileImage(props: ProfileImageProps) {
   const { setProfileImage } = props;
+  const { formDataImgFile } = useOutletContext<UserInfoFormDataContext>();
+
   const [previewImgUrl, setPreviewImgUrl] = useState("");
+
+  // MEMO :: initialize
+  useEffect(() => {
+    if (!formDataImgFile) return;
+    setPreviewImgUrl(URL.createObjectURL(formDataImgFile));
+  }, [formDataImgFile]);
 
   const handleImagePatch = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files === null) return;

--- a/src/@components/JoinPage/UserProfilePage/ProfileNickname/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileNickname/index.tsx
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 
 import { joinApi } from "../../../../core/api/join";
-import { JOIN_ERROR_KEY } from "../../../../core/join/userProfileErrorMessage";
+import { JOIN_PROFILE_ALERT_KEY } from "../../../../core/join/userProfileErrorMessage";
 import checkInvalidNickName from "../../../../util/checkInvalidNickName";
 import { St } from "./style";
 
@@ -12,7 +12,6 @@ interface ProfileNicknameProps {
   isInComplete: boolean;
   setIsChecked: (button: boolean) => void;
   handleErrorMsg: (err: string) => void;
-  isError: string;
 }
 
 export default function ProfileNickname(props: ProfileNicknameProps) {
@@ -22,7 +21,7 @@ export default function ProfileNickname(props: ProfileNicknameProps) {
     if (e.target.value.length > 8) e.target.value = e.target.value.slice(0, 8);
 
     if (nickName !== e.target.value) {
-      handleErrorMsg(JOIN_ERROR_KEY.Okay);
+      handleErrorMsg(JOIN_PROFILE_ALERT_KEY.Okay);
       setIsChecked(false);
     }
     setNickName(e.target.value);
@@ -39,17 +38,17 @@ export default function ProfileNickname(props: ProfileNicknameProps) {
     try {
       const response: AxiosResponse = await joinApi.fetchNickNameValid(nickName);
       if (checkInvalidNickName(nickName)) {
-        handleErrorMsg(JOIN_ERROR_KEY.nickName.valid);
+        handleErrorMsg(JOIN_PROFILE_ALERT_KEY.nickName.valid);
       } else if (response.data) {
-        handleErrorMsg(JOIN_ERROR_KEY.nickName.fail);
+        handleErrorMsg(JOIN_PROFILE_ALERT_KEY.nickName.fail);
       } else {
         setIsChecked(true);
-        handleErrorMsg(JOIN_ERROR_KEY.Okay);
+        handleErrorMsg(JOIN_PROFILE_ALERT_KEY.Okay);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const errorData = error.response?.data;
-        if (errorData.status === 400) handleErrorMsg(JOIN_ERROR_KEY.nickName.input);
+        if (errorData.status === 400) handleErrorMsg(JOIN_PROFILE_ALERT_KEY.nickName.input);
       }
     }
   };

--- a/src/@components/JoinPage/UserProfilePage/ProfileNickname/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileNickname/index.tsx
@@ -59,10 +59,11 @@ export default function ProfileNickname(props: ProfileNicknameProps) {
         <St.NickNameInputForm
           id="nickname"
           placeholder="홍길동"
+          defaultValue={nickName}
           onChange={onChangeNickname}
           isincompletestate={nickName === "" && isInComplete}
           isvalidstate={isChecked}
-          onKeyDown={(e) => checkSpaceBar(e)}
+          onKeyDown={checkSpaceBar}
         />
         <St.CheckBtn onClick={isVaildCheckBtn}>중복확인</St.CheckBtn>
       </St.InputContainer>

--- a/src/@components/JoinPage/UserProfilePage/ProfileNickname/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/ProfileNickname/index.tsx
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 
 import { joinApi } from "../../../../core/api/join";
+import { JOIN_ERROR_KEY } from "../../../../core/join/userProfileErrorMessage";
 import checkInvalidNickName from "../../../../util/checkInvalidNickName";
 import { St } from "./style";
 
@@ -10,18 +11,18 @@ interface ProfileNicknameProps {
   isChecked: boolean;
   isInComplete: boolean;
   setIsChecked: (button: boolean) => void;
-  errorMsg: (err: string) => void;
+  handleErrorMsg: (err: string) => void;
   isError: string;
 }
 
 export default function ProfileNickname(props: ProfileNicknameProps) {
-  const { nickName, setNickName, isChecked, setIsChecked, isInComplete, errorMsg } = props;
+  const { nickName, setNickName, isChecked, setIsChecked, isInComplete, handleErrorMsg } = props;
 
   const onChangeNickname = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length > 8) e.target.value = e.target.value.slice(0, 8);
 
     if (nickName !== e.target.value) {
-      errorMsg("");
+      handleErrorMsg(JOIN_ERROR_KEY.Okay);
       setIsChecked(false);
     }
     setNickName(e.target.value);
@@ -38,17 +39,17 @@ export default function ProfileNickname(props: ProfileNicknameProps) {
     try {
       const response: AxiosResponse = await joinApi.fetchNickNameValid(nickName);
       if (checkInvalidNickName(nickName)) {
-        errorMsg("nickNameValid");
+        handleErrorMsg(JOIN_ERROR_KEY.nickName.valid);
       } else if (response.data) {
-        errorMsg("nickNameFail");
+        handleErrorMsg(JOIN_ERROR_KEY.nickName.fail);
       } else {
         setIsChecked(true);
-        errorMsg("");
+        handleErrorMsg(JOIN_ERROR_KEY.Okay);
       }
     } catch (error) {
       if (axios.isAxiosError(error)) {
         const errorData = error.response?.data;
-        if (errorData.status === 400) errorMsg("nickNameInput");
+        if (errorData.status === 400) handleErrorMsg(JOIN_ERROR_KEY.nickName.input);
       }
     }
   };

--- a/src/@components/JoinPage/UserProfilePage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useOutletContext } from "react-router-dom";
 import { ImgDefaultBigProfile } from "../../../asset/image";
 import { JOIN_FORM_DATA_KEY } from "../../../core/join/formData";
 import { subHeaderInfo } from "../../../core/join/subHeaderInfo";
-import { errorMessage } from "../../../core/join/userProfileErrorMessage";
+import { JOIN_ERROR_KEY, JOIN_ERROR_MESSAGE } from "../../../core/join/userProfileErrorMessage";
 import { routePaths } from "../../../core/routes/path";
 import { GTM_CLASS_NAME } from "../../../util/const/gtm";
 import Footer from "../../@common/Footer";
@@ -86,22 +86,20 @@ export default function UserProfilePage() {
           isInComplete={isInComplete}
           setNickName={setNickName}
           setIsChecked={setIsChecked}
-          errorMsg={errorHandler}
+          handleErrorMsg={errorHandler}
           isError={isError}
         />
-        {(isInComplete && nickName == "") || isError === "nickNameInput" ? (
-          <St.ErrorMessage>{errorMessage.nickName.input}</St.ErrorMessage>
-        ) : isError === "nickNameFail" ? (
-          <St.ErrorMessage>{errorMessage.nickName.fail}</St.ErrorMessage>
-        ) : isError === "nickNameValid" ? (
-          <St.ErrorMessage>{errorMessage.nickName.valid}</St.ErrorMessage>
+        {(isInComplete && nickName == "") || isError === JOIN_ERROR_KEY.nickName.input ? (
+          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.input}</St.ErrorMessage>
+        ) : isError === JOIN_ERROR_KEY.nickName.fail ? (
+          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.fail}</St.ErrorMessage>
+        ) : isError === JOIN_ERROR_KEY.nickName.valid ? (
+          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.valid}</St.ErrorMessage>
         ) : isInComplete && !isChecked ? (
-          <St.ErrorMessage>{errorMessage.nickName.check}</St.ErrorMessage>
+          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.check}</St.ErrorMessage>
         ) : isChecked ? (
-          <St.SuccessMessage>{errorMessage.nickName.success}</St.SuccessMessage>
-        ) : (
-          ""
-        )}
+          <St.SuccessMessage>{JOIN_ERROR_MESSAGE.nickName.success}</St.SuccessMessage>
+        ) : null}
 
         <St.SubTitle>생년월일(필수)</St.SubTitle>
         <St.Requirement>※ 만 14세 이상만 가입가능합니다.</St.Requirement>
@@ -109,11 +107,13 @@ export default function UserProfilePage() {
           birthData={birthData}
           setBirthData={setBirthData}
           isInComplete={isInComplete}
-          errorMsg={errorHandler}
+          handleErrorMsg={errorHandler}
         />
-        {isInComplete && birthData == "" && <St.ErrorMessage>{errorMessage.birth.input}</St.ErrorMessage>}
-        {isError === "birthValid" && <St.ErrorMessage>{errorMessage.birth.valid}</St.ErrorMessage>}
-        {isError === "birthCheck" && <St.ErrorMessage>{errorMessage.birth.check}</St.ErrorMessage>}
+        {isInComplete && birthData == "" && <St.ErrorMessage>{JOIN_ERROR_MESSAGE.birth.input}</St.ErrorMessage>}
+        {isError === JOIN_ERROR_KEY.birth.valid && <St.ErrorMessage>{JOIN_ERROR_MESSAGE.birth.valid}</St.ErrorMessage>}
+        {isError === JOIN_ERROR_KEY.nickName.check && (
+          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.birth.check}</St.ErrorMessage>
+        )}
 
         <St.SubTitle>성별(선택)</St.SubTitle>
         <ProfileGender gender={gender} setGender={setGender} />

--- a/src/@components/JoinPage/UserProfilePage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 
 import { ImgDefaultBigProfile } from "../../../asset/image";
+import { JOIN_FORM_DATA_KEY } from "../../../core/join/formData";
 import { subHeaderInfo } from "../../../core/join/subHeaderInfo";
 import { errorMessage } from "../../../core/join/userProfileErrorMessage";
 import { routePaths } from "../../../core/routes/path";
@@ -18,14 +19,20 @@ import { St } from "./style";
 export default function UserProfilePage() {
   const navigate = useNavigate();
 
-  const { setUserInfoFormData } = useOutletContext<UserInfoFormDataContext>();
+  const {
+    formDataImgFileValue,
+    formDataNicknameValue,
+    formDataBirthdayValue,
+    formDataGenderValue,
+    setUserInfoFormData,
+  } = useOutletContext<UserInfoFormDataContext>();
 
-  const [nickName, setNickName] = useState(""); // 닉네임
-  const [birthData, setBirthData] = useState(""); // 생년월일
-  const [gender, setGender] = useState(""); // 성별
-  const [profileImage, setProfileImage] = useState(ImgDefaultBigProfile); // 이미지
+  const [profileImage, setProfileImage] = useState(formDataImgFileValue);
+  const [nickName, setNickName] = useState(formDataNicknameValue);
+  const [birthData, setBirthData] = useState(formDataBirthdayValue);
+  const [gender, setGender] = useState(formDataGenderValue);
 
-  const [isChecked, setIsChecked] = useState(false); //닉넴 중복 확인
+  const [isChecked, setIsChecked] = useState(false); //닉네임 중복 확인
   const [isInComplete, setisInComplete] = useState(false); // 다음으로 버튼
   const [isError, setIsError] = useState(""); // 에러메세지
 
@@ -40,11 +47,11 @@ export default function UserProfilePage() {
           currentFormData.append(pair[0], pair[1]);
         }
 
-        currentFormData.append("nickname", nickName);
-        currentFormData.append("birthday", birthData);
+        currentFormData.append(JOIN_FORM_DATA_KEY.Nickname, nickName);
+        currentFormData.append(JOIN_FORM_DATA_KEY.Birthday, birthData);
 
-        if (gender !== "") currentFormData.append("gender", gender);
-        if (profileImage) currentFormData.append("imgFile", profileImage);
+        if (gender !== "") currentFormData.append(JOIN_FORM_DATA_KEY.Gender, gender);
+        if (profileImage !== ImgDefaultBigProfile) currentFormData.append(JOIN_FORM_DATA_KEY.ImgFile, profileImage);
 
         return currentFormData;
       });

--- a/src/@components/JoinPage/UserProfilePage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/index.tsx
@@ -16,18 +16,18 @@ import ProfileNickname from "./ProfileNickname";
 import { St } from "./style";
 
 export default function UserProfilePage() {
-  const [nickName, setNickName] = useState<string>(""); // 닉네임
-  const [birthData, setBirthData] = useState<string>(""); // 생년월일
-  // TODO :: 변수명 gender로 바꾸기
-  const [isSelected, setIsSelected] = useState<string>(""); // 성별
+  const navigate = useNavigate();
+
+  const { setUserInfoFormData } = useOutletContext<UserInfoFormDataContext>();
+
+  const [nickName, setNickName] = useState(""); // 닉네임
+  const [birthData, setBirthData] = useState(""); // 생년월일
+  const [gender, setGender] = useState(""); // 성별
   const [profileImage, setProfileImage] = useState(ImgDefaultBigProfile); // 이미지
 
   const [isChecked, setIsChecked] = useState(false); //닉넴 중복 확인
   const [isInComplete, setisInComplete] = useState(false); // 다음으로 버튼
-  const [isError, setIsError] = useState<string>(""); // 에러메세지
-
-  const navigate = useNavigate();
-  const { setUserInfoFormData } = useOutletContext<UserInfoFormDataContext>();
+  const [isError, setIsError] = useState(""); // 에러메세지
 
   const completeBtn = () => {
     setisInComplete(true);
@@ -43,7 +43,7 @@ export default function UserProfilePage() {
         currentFormData.append("nickname", nickName);
         currentFormData.append("birthday", birthData);
 
-        if (isSelected) currentFormData.append("gender", isSelected);
+        if (gender !== "") currentFormData.append("gender", gender);
         if (profileImage) currentFormData.append("imgFile", profileImage);
 
         return currentFormData;
@@ -104,7 +104,7 @@ export default function UserProfilePage() {
         {isError === "birthCheck" && <St.ErrorMessage>{errorMessage.birth.check}</St.ErrorMessage>}
 
         <St.SubTitle>성별(선택)</St.SubTitle>
-        <ProfileGender isSelected={isSelected} setIsSelected={setIsSelected} />
+        <ProfileGender gender={gender} setGender={setGender} />
         <St.NextButton className={GTM_CLASS_NAME.joinProfileNext} onClick={completeBtn}>
           다음으로
         </St.NextButton>

--- a/src/@components/JoinPage/UserProfilePage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useOutletContext } from "react-router-dom";
 
-import { ImgDefaultBigProfile } from "../../../asset/image";
 import { JOIN_FORM_DATA_KEY } from "../../../core/join/formData";
 import { subHeaderInfo } from "../../../core/join/subHeaderInfo";
 import { JOIN_PROFILE_ALERT_KEY, JOIN_PROFILE_ALERT_MESSAGE } from "../../../core/join/userProfileErrorMessage";
@@ -19,15 +18,10 @@ import { St } from "./style";
 export default function UserProfilePage() {
   const navigate = useNavigate();
 
-  const {
-    formDataImgFileValue,
-    formDataNicknameValue,
-    formDataBirthdayValue,
-    formDataGenderValue,
-    setUserInfoFormData,
-  } = useOutletContext<UserInfoFormDataContext>();
+  const { formDataNicknameValue, formDataBirthdayValue, formDataGenderValue, setUserInfoFormData } =
+    useOutletContext<UserInfoFormDataContext>();
 
-  const [profileImage, setProfileImage] = useState(formDataImgFileValue);
+  const [profileImage, setProfileImage] = useState<File>();
   const [nickName, setNickName] = useState(formDataNicknameValue);
   const [birthData, setBirthData] = useState(formDataBirthdayValue);
   const [gender, setGender] = useState(formDataGenderValue);
@@ -48,16 +42,12 @@ export default function UserProfilePage() {
       setUserInfoFormData((prevFormData) => {
         const currentFormData = new FormData();
 
-        // email, password
-        for (const pair of prevFormData.entries()) {
-          currentFormData.append(pair[0], pair[1]);
-        }
-
+        currentFormData.append(JOIN_FORM_DATA_KEY.Email, prevFormData.get(JOIN_FORM_DATA_KEY.Email) ?? "");
+        currentFormData.append(JOIN_FORM_DATA_KEY.Password, prevFormData.get(JOIN_FORM_DATA_KEY.Password) ?? "");
         currentFormData.append(JOIN_FORM_DATA_KEY.Nickname, nickName);
         currentFormData.append(JOIN_FORM_DATA_KEY.Birthday, birthData);
-
         if (gender !== "") currentFormData.append(JOIN_FORM_DATA_KEY.Gender, gender);
-        if (profileImage !== ImgDefaultBigProfile) currentFormData.append(JOIN_FORM_DATA_KEY.ImgFile, profileImage);
+        if (profileImage) currentFormData.append(JOIN_FORM_DATA_KEY.ImgFile, profileImage);
 
         return currentFormData;
       });

--- a/src/@components/JoinPage/UserProfilePage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/index.tsx
@@ -38,6 +38,11 @@ export default function UserProfilePage() {
 
   const completeBtn = () => {
     setisInComplete(true);
+    // 중복확인
+    if (!isChecked) {
+      return;
+    }
+
     if (nickName && birthData && isError === "") {
       setUserInfoFormData((prevFormData) => {
         const currentFormData = new FormData();

--- a/src/@components/JoinPage/UserProfilePage/index.tsx
+++ b/src/@components/JoinPage/UserProfilePage/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useOutletContext } from "react-router-dom";
 import { ImgDefaultBigProfile } from "../../../asset/image";
 import { JOIN_FORM_DATA_KEY } from "../../../core/join/formData";
 import { subHeaderInfo } from "../../../core/join/subHeaderInfo";
-import { JOIN_ERROR_KEY, JOIN_ERROR_MESSAGE } from "../../../core/join/userProfileErrorMessage";
+import { JOIN_PROFILE_ALERT_KEY, JOIN_PROFILE_ALERT_MESSAGE } from "../../../core/join/userProfileErrorMessage";
 import { routePaths } from "../../../core/routes/path";
 import { GTM_CLASS_NAME } from "../../../util/const/gtm";
 import Footer from "../../@common/Footer";
@@ -34,16 +34,17 @@ export default function UserProfilePage() {
 
   const [isChecked, setIsChecked] = useState(false); //닉네임 중복 확인
   const [isInComplete, setisInComplete] = useState(false); // 다음으로 버튼
-  const [isError, setIsError] = useState(""); // 에러메세지
+  const [errorKey, setErrorKey] = useState(""); // 에러메세지
 
   const completeBtn = () => {
     setisInComplete(true);
+
     // 중복확인
     if (!isChecked) {
       return;
     }
 
-    if (nickName && birthData && isError === "") {
+    if (nickName && birthData && errorKey === "") {
       setUserInfoFormData((prevFormData) => {
         const currentFormData = new FormData();
 
@@ -66,7 +67,7 @@ export default function UserProfilePage() {
   };
 
   const errorHandler = (err: string) => {
-    setIsError(err);
+    setErrorKey(err);
   };
 
   return (
@@ -87,18 +88,17 @@ export default function UserProfilePage() {
           setNickName={setNickName}
           setIsChecked={setIsChecked}
           handleErrorMsg={errorHandler}
-          isError={isError}
         />
-        {(isInComplete && nickName == "") || isError === JOIN_ERROR_KEY.nickName.input ? (
-          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.input}</St.ErrorMessage>
-        ) : isError === JOIN_ERROR_KEY.nickName.fail ? (
-          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.fail}</St.ErrorMessage>
-        ) : isError === JOIN_ERROR_KEY.nickName.valid ? (
-          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.valid}</St.ErrorMessage>
+        {(isInComplete && nickName === "") || errorKey === JOIN_PROFILE_ALERT_KEY.nickName.input ? (
+          <St.ErrorMessage>{JOIN_PROFILE_ALERT_MESSAGE.nickName.input}</St.ErrorMessage>
+        ) : errorKey === JOIN_PROFILE_ALERT_KEY.nickName.fail ? (
+          <St.ErrorMessage>{JOIN_PROFILE_ALERT_MESSAGE.nickName.fail}</St.ErrorMessage>
+        ) : errorKey === JOIN_PROFILE_ALERT_KEY.nickName.valid ? (
+          <St.ErrorMessage>{JOIN_PROFILE_ALERT_MESSAGE.nickName.valid}</St.ErrorMessage>
         ) : isInComplete && !isChecked ? (
-          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.nickName.check}</St.ErrorMessage>
+          <St.ErrorMessage>{JOIN_PROFILE_ALERT_MESSAGE.nickName.check}</St.ErrorMessage>
         ) : isChecked ? (
-          <St.SuccessMessage>{JOIN_ERROR_MESSAGE.nickName.success}</St.SuccessMessage>
+          <St.SuccessMessage>{JOIN_PROFILE_ALERT_MESSAGE.nickName.success}</St.SuccessMessage>
         ) : null}
 
         <St.SubTitle>생년월일(필수)</St.SubTitle>
@@ -109,10 +109,14 @@ export default function UserProfilePage() {
           isInComplete={isInComplete}
           handleErrorMsg={errorHandler}
         />
-        {isInComplete && birthData == "" && <St.ErrorMessage>{JOIN_ERROR_MESSAGE.birth.input}</St.ErrorMessage>}
-        {isError === JOIN_ERROR_KEY.birth.valid && <St.ErrorMessage>{JOIN_ERROR_MESSAGE.birth.valid}</St.ErrorMessage>}
-        {isError === JOIN_ERROR_KEY.nickName.check && (
-          <St.ErrorMessage>{JOIN_ERROR_MESSAGE.birth.check}</St.ErrorMessage>
+        {isInComplete && birthData === "" && (
+          <St.ErrorMessage>{JOIN_PROFILE_ALERT_MESSAGE.birth.input}</St.ErrorMessage>
+        )}
+        {errorKey === JOIN_PROFILE_ALERT_KEY.birth.valid && (
+          <St.ErrorMessage>{JOIN_PROFILE_ALERT_MESSAGE.birth.valid}</St.ErrorMessage>
+        )}
+        {errorKey === JOIN_PROFILE_ALERT_KEY.birth.check && (
+          <St.ErrorMessage>{JOIN_PROFILE_ALERT_MESSAGE.birth.check}</St.ErrorMessage>
         )}
 
         <St.SubTitle>성별(선택)</St.SubTitle>

--- a/src/@components/JoinPage/index.tsx
+++ b/src/@components/JoinPage/index.tsx
@@ -4,7 +4,7 @@ import { Outlet } from "react-router-dom";
 import { JOIN_FORM_DATA_KEY } from "../../core/join/formData";
 
 export interface UserInfoFormDataContext {
-  userInfoFormData: FormData;
+  userInfoFormDataForPost: FormData;
   formDataEmailValue: string;
   formDataPasswordValue: string;
   formDataNicknameValue: string;
@@ -19,7 +19,7 @@ export default function JoinPage() {
   return (
     <Outlet
       context={{
-        userInfoFormData,
+        userInfoFormDataForPost: userInfoFormData,
         formDataEmailValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Email) ?? "",
         formDataPasswordValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Password) ?? "",
         formDataNicknameValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Nickname) ?? "",

--- a/src/@components/JoinPage/index.tsx
+++ b/src/@components/JoinPage/index.tsx
@@ -1,14 +1,12 @@
 import { useState } from "react";
 import { Outlet } from "react-router-dom";
 
-import { ImgDefaultBigProfile } from "../../asset/image";
 import { JOIN_FORM_DATA_KEY } from "../../core/join/formData";
 
 export interface UserInfoFormDataContext {
   userInfoFormData: FormData;
   formDataEmailValue: string;
   formDataPasswordValue: string;
-  formDataImgFileValue: File;
   formDataNicknameValue: string;
   formDataBirthdayValue: string;
   formDataGenderValue: string;
@@ -27,7 +25,6 @@ export default function JoinPage() {
         formDataNicknameValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Nickname) ?? "",
         formDataBirthdayValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Birthday) ?? "",
         formDataGenderValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Gender) ?? "",
-        formDataImgFileValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.ImgFile) ?? ImgDefaultBigProfile,
         setUserInfoFormData,
       }}
     />

--- a/src/@components/JoinPage/index.tsx
+++ b/src/@components/JoinPage/index.tsx
@@ -1,13 +1,35 @@
 import { useState } from "react";
 import { Outlet } from "react-router-dom";
 
+import { ImgDefaultBigProfile } from "../../asset/image";
+import { JOIN_FORM_DATA_KEY } from "../../core/join/formData";
+
 export interface UserInfoFormDataContext {
   userInfoFormData: FormData;
+  formDataEmailValue: string;
+  formDataPasswordValue: string;
+  formDataImgFileValue: File;
+  formDataNicknameValue: string;
+  formDataBirthdayValue: string;
+  formDataGenderValue: string;
   setUserInfoFormData: React.Dispatch<React.SetStateAction<FormData>>;
 }
 
 export default function JoinPage() {
   const [userInfoFormData, setUserInfoFormData] = useState<FormData>(new FormData());
 
-  return <Outlet context={{ userInfoFormData, setUserInfoFormData }} />;
+  return (
+    <Outlet
+      context={{
+        userInfoFormData,
+        formDataEmailValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Email) ?? "",
+        formDataPasswordValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Password) ?? "",
+        formDataNicknameValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Nickname) ?? "",
+        formDataBirthdayValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Birthday) ?? "",
+        formDataGenderValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Gender) ?? "",
+        formDataImgFileValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.ImgFile) ?? ImgDefaultBigProfile,
+        setUserInfoFormData,
+      }}
+    />
+  );
 }

--- a/src/@components/JoinPage/index.tsx
+++ b/src/@components/JoinPage/index.tsx
@@ -10,6 +10,7 @@ export interface UserInfoFormDataContext {
   formDataNicknameValue: string;
   formDataBirthdayValue: string;
   formDataGenderValue: string;
+  formDataImgFile: File;
   setUserInfoFormData: React.Dispatch<React.SetStateAction<FormData>>;
 }
 
@@ -25,6 +26,7 @@ export default function JoinPage() {
         formDataNicknameValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Nickname) ?? "",
         formDataBirthdayValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Birthday) ?? "",
         formDataGenderValue: userInfoFormData.get(JOIN_FORM_DATA_KEY.Gender) ?? "",
+        formDataImgFile: userInfoFormData.get(JOIN_FORM_DATA_KEY.ImgFile),
         setUserInfoFormData,
       }}
     />

--- a/src/core/join/formData.ts
+++ b/src/core/join/formData.ts
@@ -1,0 +1,8 @@
+export const JOIN_FORM_DATA_KEY = {
+  Email: "email",
+  Password: "password",
+  ImgFile: "imgFile",
+  Nickname: "nickname",
+  Birthday: "birthday",
+  Gender: "gender",
+};

--- a/src/core/join/userProfileErrorMessage.ts
+++ b/src/core/join/userProfileErrorMessage.ts
@@ -1,4 +1,20 @@
-export const errorMessage = {
+export const JOIN_ERROR_KEY = {
+  Okay: "",
+  nickName: {
+    input: "nickNameInput",
+    check: "닉네임 중복 확인을 해주세요",
+    valid: "nickNameValid",
+    fail: "nickNameFail",
+    success: "사용가능한 닉네임입니다",
+  },
+  birth: {
+    input: "생년월일을 입력해주세요",
+    check: "birthCheck",
+    valid: "birthValid",
+  },
+};
+
+export const JOIN_ERROR_MESSAGE = {
   nickName: {
     input: "닉네임을 입력해주세요",
     check: "닉네임 중복 확인을 해주세요",

--- a/src/core/join/userProfileErrorMessage.ts
+++ b/src/core/join/userProfileErrorMessage.ts
@@ -1,20 +1,20 @@
-export const JOIN_ERROR_KEY = {
+export const JOIN_PROFILE_ALERT_KEY = {
   Okay: "",
   nickName: {
     input: "nickNameInput",
-    check: "닉네임 중복 확인을 해주세요",
+    // check: "닉네임 중복 확인을 해주세요",
     valid: "nickNameValid",
     fail: "nickNameFail",
-    success: "사용가능한 닉네임입니다",
+    // success: "사용가능한 닉네임입니다",
   },
   birth: {
-    input: "생년월일을 입력해주세요",
+    // input: "생년월일을 입력해주세요",
     check: "birthCheck",
     valid: "birthValid",
   },
 };
 
-export const JOIN_ERROR_MESSAGE = {
+export const JOIN_PROFILE_ALERT_MESSAGE = {
   nickName: {
     input: "닉네임을 입력해주세요",
     check: "닉네임 중복 확인을 해주세요",


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [x] 브랜치명, 브랜치 알맞게 설정
- [x] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [ ] PR이 승인된 경우 해당 브랜치는 삭제하기

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
`3h`
#### join
- 에러 처리에 필요한 변수명들을 상수화 해놨습니다.
- `Feat` 이전으로 돌아가도 정보가 남아있습니다. (defualt 값 설정 :: 이메일, 비밀번호, 프로필사진, 닉네임, 생일, 성별)
#### join/user-profile
- `Fix` 닉네임 중복 이후에 다음 단계로 넘어갈 수 있습니다.
#### join/agree
- `Feat` 동의 페이지에서, 필수 조건들에 기본적으로 체크 처리를 해놓았습니다. (토스 앱에서 "필수"인 값에 먼저 체크를 해놓고, "선택" 부분만 사용자가 체크하도록 UI/UX를 구성해놓았는데, 편리한 것 같아서 해봤어요 하하😇😇 이거는 dev 반영 이후에 기획측 확인을 받으려구요!!)
- `Fix` 회원가입 POST 통신이 안됐는데(창을 나갔다와서 값이 사라진 상황이라던가 하는... , 로그인 페이지로 넘어가는 현상이 있어서, alert로 에러 메시지를 띄워주도록 구성했어요. 이것도 이후에 기획측 확인을 받을게요!! 
    - recoil persist 같은 **로컬스토리지 저장**이 필요할까도 싶어요.)

<br />

## 📸 스크린샷
<!--작업한 내용에서 UI 변화가 있다면 스크린샷을 첨부해주세요-->
<!--이미지 업로드(복붙) 후 src="(링크)" 형태로 넣어조요-->
<img src="https://user-images.githubusercontent.com/121784376/221492367-8e292d62-6b60-4b13-ad36-983e3b38941f.png" width=40% />
<img src="https://user-images.githubusercontent.com/121784376/221492402-4c742bb1-d761-422a-a21e-ffb64039d8ee.png" width=40% />
<img src="https://user-images.githubusercontent.com/121784376/221493346-bdd95201-040c-4863-82dc-61d31d66b4af.png" width=40% />