### PR TITLE
[ refactor ] bestPiickle 우측 여백 조정

### DIFF
--- a/src/@components/MainPage/BestPiickle/BestPiickleCard/index.tsx
+++ b/src/@components/MainPage/BestPiickle/BestPiickleCard/index.tsx
@@ -30,7 +30,7 @@ export default function BestPiickleCard(props: BestPiickleCardProps) {
         if (!canNavigate) return;
         navigateCardCollection(idx);
       }}>
-      <St.BestPiickleCard>
+      <St.BestPiickleCard cardIdx={idx}>
         <St.TagsWrapper>
           {tags.map((tag: string, i: number) => {
             return <St.Tag key={i}>{tag.slice(1)}</St.Tag>;

--- a/src/@components/MainPage/BestPiickle/BestPiickleCard/style.ts
+++ b/src/@components/MainPage/BestPiickle/BestPiickleCard/style.ts
@@ -2,13 +2,13 @@ import styled from "styled-components";
 
 const Container = styled.button``;
 
-const BestPiickleCard = styled.article`
+const BestPiickleCard = styled.article<{ cardIdx: number }>`
   position: relative;
 
   width: 20rem;
   height: 13.6rem;
 
-  margin-right: 0.8rem;
+  margin-right: ${({ cardIdx }) => (cardIdx === 4 ? 1.6 : 0.8)}rem;
   padding: 1.2rem;
 
   border: 0.1rem solid ${({ theme }) => theme.newColors.gray300};

--- a/src/@components/MainPage/BestPiickle/style.ts
+++ b/src/@components/MainPage/BestPiickle/style.ts
@@ -8,7 +8,7 @@ const SliderWrapper = styled.article`
   display: flex;
   overflow-x: scroll;
 
-  padding: 0 1.6rem;
+  padding-left: 1.6rem;
 
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [x] 브랜치명, 브랜치 알맞게 설정
- [x] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [ ] PR이 승인된 경우 해당 브랜치는 삭제하기

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
- bestPiickle 우측 여백 값을 1.6rem으로 통일시킵니다.
- 굳이 인덱스 값을 프롭스로 준 이유는,,,, 제 아이폰12에서 우측 padding값이 안먹기 때문입니다.. margin 값만 먹더라구요😥

<br />

## 📸 스크린샷
<!--작업한 내용에서 UI 변화가 있다면 스크린샷을 첨부해주세요-->
<!--이미지 업로드(복붙) 후 src="(링크)" 형태로 넣어조요-->
<img src="https://user-images.githubusercontent.com/71490862/227225069-ea3d316e-f1a2-487e-8fa8-f27de105430b.png" width=50% />
