### PR TITLE
[ feat ] opacity 클릭 시, modal 닫기 기능만 작동하도록 구현

### DIFF
--- a/src/@components/@common/hooks/useOutClickCloser.ts
+++ b/src/@components/@common/hooks/useOutClickCloser.ts
@@ -9,12 +9,14 @@ export default function useOutClickCloser(handleOutClickCloser: HandleOutClickCl
     const handleClickOutside = (e: MouseEvent | TouchEvent) => {
       if (!(e.target instanceof HTMLElement)) return;
       if (currentRef.current && !currentRef.current.contains(e.target)) {
+        e.preventDefault();
+        e.stopPropagation();
         handleOutClickCloser();
       }
     };
 
     document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("touchstart", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside, { passive: false });
 
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [x] 브랜치명, 브랜치 알맞게 설정
- [x] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [ ] PR이 승인된 경우 해당 브랜치는 삭제하기

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
- 모달의 opacity 클릭 시, opacity 뒤에 있던 기능들이 작동되지 않도록 구현했습니다.


<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자ㅑ (기록하면서 개발하기!) -->
- 이벤트의 전파를 막는 `e.stopPropagation()`에 대해 알게 되었습니다! `e.stopPropagation()`는 전파는 막지만, 이벤트의 기본 동작은 막지 못해서 `e.preventDefault()`를 같이 써주었습니당

<br />

## 📌 질문할 부분 
<!-- 작은 거라도 조아  -->
- 아래 첨부한 동영상처럼, 메들리(혹은 메뉴바)를 클릭하면 뒤에 메들리 배너가 깜박이는 것을 해결해나가야 할 것 같아여,,
어떨 때는 또 깜박임이 없어서, 저처럼 작동하는지 한 번 확인해주실 수 있을까요?-?

<br />

## 📸 스크린샷
<!--작업한 내용에서 UI 변화가 있다면 스크린샷을 첨부해주세요-->
<!--이미지 업로드(복붙) 후 src="(링크)" 형태로 넣어조요-->
<img src="https://user-images.githubusercontent.com/71490862/227553474-525980e2-505f-4e7f-bace-d00826fcfa57.mp4" width=80% />



