### PR TITLE
Feat/#290 Card Collection Url using Query String

### DIFF
--- a/src/@components/@common/Header/index.tsx
+++ b/src/@components/@common/Header/index.tsx
@@ -1,12 +1,9 @@
-import { lazy } from "react";
-
 import { IcHamburger, IcLogo } from "../../../asset/icon";
 import { routePaths } from "../../../core/routes/path";
 import { GTM_CLASS_NAME } from "../../../util/const/gtm";
 import useModal from "../hooks/useModal";
+import MenuBar from "../MenuBar";
 import * as St from "./style";
-
-const MenuBar = lazy(() => import("../MenuBar"));
 
 export default function Header() {
   const { isModalOpen, toggleModal } = useModal();

--- a/src/@components/@common/hooks/useNavigateCardCollection.ts
+++ b/src/@components/@common/hooks/useNavigateCardCollection.ts
@@ -51,7 +51,7 @@ export default function useNavigateCardCollection(locationType: LocationType) {
 
     case LocationType.MEDLEY:
       return (medleyId: string, sliderIdx = 0) => {
-        navigate(routePaths.CardCollection, { state: { type: LocationType.MEDLEY, medleyId } });
+        navigate(`${routePaths.CardCollection}?type=${LocationType.MEDLEY}?medleyId=${medleyId}`);
         setSliderIdx(sliderIdx);
       };
   }

--- a/src/@components/@common/hooks/useNavigateCardCollection.ts
+++ b/src/@components/@common/hooks/useNavigateCardCollection.ts
@@ -37,7 +37,7 @@ export default function useNavigateCardCollection(locationType: LocationType) {
 
     case LocationType.CATEGORY:
       return (categoryId: string, sliderIdx = 0) => {
-        navigate(routePaths.CardCollection, { state: { type: LocationType.CATEGORY, categoryId } });
+        navigate(`${routePaths.CardCollection}?type=${LocationType.CATEGORY}?categoryId=${categoryId}`);
         setSliderIdx(sliderIdx);
       };
 

--- a/src/@components/@common/hooks/useNavigateCardCollection.ts
+++ b/src/@components/@common/hooks/useNavigateCardCollection.ts
@@ -25,13 +25,13 @@ export default function useNavigateCardCollection(locationType: LocationType) {
 
     case LocationType.BEST:
       return (sliderIdx = 0) => {
-        navigate(routePaths.CardCollection, { state: { type: LocationType.BEST } });
+        navigate(`${routePaths.CardCollection}?type=${LocationType.BEST}`);
         setSliderIdx(sliderIdx);
       };
 
     case LocationType.BOOKMARK:
       return (sliderIdx = 0) => {
-        navigate(routePaths.CardCollection, { state: { type: LocationType.BOOKMARK } });
+        navigate(`${routePaths.CardCollection}?type=${LocationType.BOOKMARK}`);
         setSliderIdx(sliderIdx);
       };
 

--- a/src/@components/@common/hooks/useNavigateCardCollection.ts
+++ b/src/@components/@common/hooks/useNavigateCardCollection.ts
@@ -1,3 +1,4 @@
+import qs from "qs";
 import { useNavigate } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
 
@@ -37,22 +38,33 @@ export default function useNavigateCardCollection(locationType: LocationType) {
 
     case LocationType.CATEGORY:
       return (categoryId: string, sliderIdx = 0) => {
-        navigate(`${routePaths.CardCollection}?type=${LocationType.CATEGORY}?categoryId=${categoryId}`);
+        navigate(`${routePaths.CardCollection}?type=${LocationType.CATEGORY}&categoryId=${categoryId}`);
         setSliderIdx(sliderIdx);
       };
 
     case LocationType.FILTER:
       return (filterTypes: string[], sliderIdx = 0) => {
-        navigate(routePaths.CardCollection, {
-          state: { type: LocationType.FILTER, filterTypes },
-        });
+        navigate(
+          `${routePaths.CardCollection}?type=${LocationType.FILTER}&filterTypes=${parseFilterTypesToString(
+            filterTypes,
+          )}`,
+        );
         setSliderIdx(sliderIdx);
       };
 
     case LocationType.MEDLEY:
       return (medleyId: string, sliderIdx = 0) => {
-        navigate(`${routePaths.CardCollection}?type=${LocationType.MEDLEY}?medleyId=${medleyId}`);
+        navigate(`${routePaths.CardCollection}?type=${LocationType.MEDLEY}&medleyId=${medleyId}`);
         setSliderIdx(sliderIdx);
       };
   }
+}
+
+function parseFilterTypesToString(filterTypes: string[]): string {
+  return qs.stringify(
+    {
+      search: filterTypes,
+    },
+    { arrayFormat: "repeat" },
+  );
 }

--- a/src/@components/@common/hooks/useNavigateCardCollection.ts
+++ b/src/@components/@common/hooks/useNavigateCardCollection.ts
@@ -19,7 +19,7 @@ export default function useNavigateCardCollection(locationType: LocationType) {
   switch (locationType) {
     case LocationType.ALL:
       return (sliderIdx = 0) => {
-        navigate(routePaths.CardCollection, { state: { type: LocationType.ALL } });
+        navigate(`${routePaths.CardCollection}?type=${LocationType.ALL}`);
         setSliderIdx(sliderIdx);
       };
 

--- a/src/@components/CardCollectionPage/hooks/useCardLists.ts
+++ b/src/@components/CardCollectionPage/hooks/useCardLists.ts
@@ -1,4 +1,5 @@
 import qs from "qs";
+import { useLocation } from "react-router-dom";
 import useSWR from "swr";
 
 import { realReq } from "../../../core/api/common/axios";
@@ -12,9 +13,13 @@ interface ExtendedCardList extends Array<CardList> {
   cards?: CardList[]; // with medly id
 }
 
-export function useCardLists(cardsTypeLocation: CardsTypeLocation) {
+export function useCardLists() {
+  const location = useLocation();
+  const cardsTypeLocation = getLocationInfoByQueries(location.search);
+
   const fetchingKeyByLocation = getSWRFetchingKeyByLocation(cardsTypeLocation);
   const optionsByLocation = getSWROptionsByLocation(cardsTypeLocation);
+
   const { data } = useSWR<PiickleSWRResponse<ExtendedCardList>>(
     fetchingKeyByLocation,
     realReq.GET_SWR,
@@ -41,6 +46,18 @@ function getReturnCardLists(
     default:
       return data?.data.data;
   }
+}
+
+function getLocationInfoByQueries(queries: string): CardsTypeLocation {
+  return queries
+    .split("?")
+    .splice(1)
+    .reduce((acc: { [key: string]: string }, query) => {
+      const [key, value] = query.split("=");
+      acc[key] = value;
+
+      return acc;
+    }, {}) as unknown as CardsTypeLocation;
 }
 
 function getSWRFetchingKeyByLocation(cardsTypeLocation: CardsTypeLocation) {

--- a/src/@components/CardCollectionPage/hooks/useCardLists.ts
+++ b/src/@components/CardCollectionPage/hooks/useCardLists.ts
@@ -20,7 +20,6 @@ export function useCardLists() {
   const fetchingKeyByLocation = getSWRFetchingKeyByLocation(cardsTypeLocation);
   const optionsByLocation = getSWROptionsByLocation(cardsTypeLocation);
 
-  console.log("cardsTypeLocation", cardsTypeLocation);
   const { data } = useSWR<PiickleSWRResponse<ExtendedCardList>>(
     fetchingKeyByLocation,
     realReq.GET_SWR,
@@ -108,8 +107,6 @@ function getSWROptionsByLocation(cardsTypeLocation: CardsTypeLocation) {
     case LocationType.BOOKMARK:
     case LocationType.MEDLEY:
       return { suspense: true };
-    // case LocationType.FILTER:
-    //   return { suspense: true, revalidateOnMount: false };
     default:
       return { suspense: true, revalidateOnMount: true, dedupingInterval: 700 };
   }

--- a/src/@components/CardCollectionPage/index.tsx
+++ b/src/@components/CardCollectionPage/index.tsx
@@ -1,8 +1,6 @@
-import { useLocation } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 
 import { isSliderDownState } from "../../core/atom/slider";
-import { CardsTypeLocation } from "../../types/cardCollection";
 import { GTM_CLASS_NAME } from "../../util/const/gtm";
 import HeadlessCTAButton from "../@common/CTABtn/HeadlessCTAButton";
 import Header from "../@common/Header";
@@ -30,9 +28,7 @@ function CardCollectionContent() {
   useGTMPage();
   useScroll();
 
-  const location = useLocation();
-  const cardsTypeLoaction = location.state as CardsTypeLocation;
-  const { cardLists, fetchCardListsWithFilter } = useCardLists(cardsTypeLoaction);
+  const { cardLists, fetchCardListsWithFilter } = useCardLists();
 
   const { isVisibleCTAButton, intersectionObserverRef: lastCardObsvRef } = useCTAFilter();
 

--- a/src/types/cardCollection.ts
+++ b/src/types/cardCollection.ts
@@ -25,7 +25,7 @@ interface CategoryTypeLocation {
 
 interface FilterTypeLocation {
   type: LocationType.FILTER;
-  filterTypes: string[];
+  filterTypes: string;
 }
 
 interface MedleyTypeLocation {


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [x] 브랜치명, 브랜치 알맞게 설정
- [x] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [ ] PR이 승인된 경우 해당 브랜치는 삭제하기

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
- 카드 공유하기를 위해 url 데이터로써 navigate 할 수 있게끔 바꿔놓았어요. 
- 기존의 navigate state로 주고받던 데이터를 url 의 query string으로 주고받습니다.
- filter type 같은 경우에는 `?type=filter&filterTypes=search=A필터&search=B필터&search=C필터` 형식으로 되어 있어, 정보를 파싱해주는 `getLocationInfoByQueryString` 함수 부분이 좀 더러워졌어요. 이후에 여유가 있을 때 리팩토링 해보겠습니다,,
- **중요한 부분이고 엣지 케이스가 있을 수 있어서, qa 확실하게 하고 넘어가야 할 것 같아요**