### PR TITLE
Fix/#307 HeadingTitle 에러

### DIFF
--- a/src/@components/BookmarkPage/index.tsx
+++ b/src/@components/BookmarkPage/index.tsx
@@ -11,7 +11,6 @@ import * as St from "./style";
 const bookmarkHeadingTitles: HeadingTitle = {
   title: "MY Piickle",
   content: "내가 픽한 대화 주제들을 확인해보세요",
-  isMoreBtn: false,
 };
 
 export default function BookmarkPage() {


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [x] 브랜치명, 브랜치 알맞게 설정
- [x] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [x] PR이 승인된 경우 해당 브랜치는 삭제하기 close #307 

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
- `HeadingTitle`의 isMoreBtn 속성을 삭제하면서 미처 수정사항을 반영하지 못했었습니다.
- 공통 타입 `HeadingTitle`을 사용하고 있는 모든 부분 에러 안나는지 검사 완료했습니다.


<br />

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자ㅑ (기록하면서 개발하기!) -->
- 공통 부분을 수정하면 다 확인해보자 : )
