### PR TITLE
Fix/#322 login modal

### DIFF
--- a/src/@components/@common/LoginModal/index.tsx
+++ b/src/@components/@common/LoginModal/index.tsx
@@ -21,29 +21,16 @@ export default function LoginModal(props: LoginCheckProps) {
         <St.Wrapper>
           <St.ModalContents>로그인을 하시면 {contents} 이용할 수 있어요</St.ModalContents>
         </St.Wrapper>
-        <St.Buttons>
-          <St.Button
-            type="button"
-            // 투표에서의 로그인인지, 카드 좋아요에서의 로그인인지
-            className={voteLoginClassName ? voteLoginClassName : GTM_CLASS_NAME.cardLogin}
-            onClick={() => {
-              closeHandler();
-              navigate(routePaths.Login);
-            }}>
-            로그인
-          </St.Button>
-          <St.Button
-            type="button"
-            // 투표에서의 회원가입인지, 카드 좋아요에서의 회원가입인지
-            className={voteJoinClassName ? voteJoinClassName : GTM_CLASS_NAME.cardJoin}
-            onClick={() => {
-              closeHandler();
-              // navigate(`${routePaths.Join_}${routePaths.Join_EmailAuthentication}`);
-              navigate(`${routePaths.Join_}${routePaths.Join_UserInfo}`);
-            }}>
-            회원가입
-          </St.Button>
-        </St.Buttons>
+        <St.Button
+          type="button"
+          // 투표에서의 로그인인지, 카드 좋아요에서의 로그인인지
+          className={voteLoginClassName ? voteLoginClassName : GTM_CLASS_NAME.cardLogin}
+          onClick={() => {
+            closeHandler();
+            navigate(routePaths.Login);
+          }}>
+          로그인 하기
+        </St.Button>
       </St.Container>
     </Modal>
   );

--- a/src/@components/@common/LoginModal/style.ts
+++ b/src/@components/@common/LoginModal/style.ts
@@ -6,9 +6,8 @@ export const Container = styled.section`
   justify-content: space-between;
   align-items: center;
 
-  margin-top: 6.4rem;
-
-  height: 13.6rem;
+  margin-top: 7.4rem;
+  padding: 0 0.8rem;
 `;
 
 export const Wrapper = styled.div`
@@ -20,17 +19,11 @@ export const ModalContents = styled.p`
   color: ${({ theme }) => theme.newColors.gray900};
 `;
 
-export const Buttons = styled.div`
-  width: 100%;
-
-  display: flex;
-  gap: 0.01rem;
-
-  height: 5.8rem;
-`;
-
 export const Button = styled.button`
   width: 100%;
+  height: 5.6rem;
+  border-radius: 0.8rem;
+  margin-top: 4.4rem;
 
   display: flex;
   justify-content: center;
@@ -41,8 +34,4 @@ export const Button = styled.button`
   ${({ theme }) => theme.newFonts.btn1};
   color: ${({ theme }) => theme.newColors.gray100};
   background: ${({ theme }) => theme.newColors.gray900};
-
-  &:first-child {
-    margin-right: 0.1rem;
-  }
 `;

--- a/src/@components/BestPiicklePage/BestPiickleRank/RankItem/index.tsx
+++ b/src/@components/BestPiicklePage/BestPiickleRank/RankItem/index.tsx
@@ -7,7 +7,7 @@ import useCardBookmark from "../../../CardCollectionPage/hooks/useCardBookmark";
 import * as St from "./style";
 
 interface RankItemProps {
-  openLoginModalHandler: () => void;
+  onClickLogoutBookmark: () => void;
   cardId: string;
   content: string;
   rank: number;
@@ -15,11 +15,11 @@ interface RankItemProps {
 }
 
 export default function RankItem(props: RankItemProps) {
-  const { cardId, content, rank, isBookmark, openLoginModalHandler } = props;
+  const { cardId, content, rank, isBookmark, onClickLogoutBookmark } = props;
 
   const navigateRankCollection = useNavigateCardCollection(LocationType.BEST) as NavigateCardCollectionBookMarkType;
 
-  const { isBookmarked, handleClickBookmark } = useCardBookmark(isBookmark, openLoginModalHandler);
+  const { isBookmarked, handleClickBookmark } = useCardBookmark(isBookmark, onClickLogoutBookmark);
 
   return (
     <St.RankItemContainer>

--- a/src/@components/BestPiicklePage/BestPiickleRank/index.tsx
+++ b/src/@components/BestPiicklePage/BestPiickleRank/index.tsx
@@ -34,7 +34,7 @@ export default function BestPiickleRank() {
               content={content}
               rank={idx}
               isBookmark={isBookmark}
-              openLoginModalHandler={toggleLoginModal}
+              onClickLogoutBookmark={toggleLoginModal}
             />
           ))}
       <St.ButtonWrapper>

--- a/src/@components/CardCollectionPage/Card/CardMenu/index.tsx
+++ b/src/@components/CardCollectionPage/Card/CardMenu/index.tsx
@@ -9,15 +9,15 @@ import * as St from "./style";
 interface CardMenuProps {
   _id: string;
   isBookmark: boolean;
-  openLoginModalHandler: () => void;
+  onClickLogoutBookmark: () => void;
   toggleMenuModal: () => void;
 }
 
 export default function CardMenu(props: CardMenuProps) {
-  const { _id, isBookmark, openLoginModalHandler, toggleMenuModal } = props;
+  const { _id, isBookmark, onClickLogoutBookmark, toggleMenuModal } = props;
 
   const { handleCopyClipBoard } = useCardShare();
-  const { isBookmarked, handleClickBookmark } = useCardBookmark(isBookmark, openLoginModalHandler);
+  const { isBookmarked, handleClickBookmark } = useCardBookmark(isBookmark, onClickLogoutBookmark);
 
   return (
     <St.MenuContainer>

--- a/src/@components/CardCollectionPage/Card/index.tsx
+++ b/src/@components/CardCollectionPage/Card/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { GTM_CLASS_NAME } from "../../../util/const/gtm";
 import useModal from "../../@common/hooks/useModal";
+import LoginModal from "../../@common/LoginModal";
 import useBlacklist from "../hooks/useBlacklist";
 import { autoSlideType } from "../hooks/useCardSwiper";
 import TagsSlider from "../TagsSlider";
@@ -15,13 +16,15 @@ interface LoginCheckProps {
   content: string;
   isBookmark: boolean;
   tags: string[];
-  openLoginModalHandler: () => void;
 }
 
 const Card = (props: LoginCheckProps) => {
-  const { _id, content, tags, autoSlide, openLoginModalHandler } = props;
+  const { _id, content, tags, autoSlide } = props;
   const { isModalOpen: isMenuModalOpen, toggleModal: toggleMenuModal } = useModal();
-  const { getIsBlacklist, handleClickAddBlacklist, handleClickCancelBlacklist } = useBlacklist(openLoginModalHandler);
+  const { isModalOpen: isBookmarkModalOpen, toggleModal: toggleBookmarkModalOpen } = useModal();
+  const { isModalOpen: isBlacklistModalOpen, toggleModal: toggleBlacklistModalOpen } = useModal();
+  const { getIsBlacklist, handleClickAddBlacklist, handleClickCancelBlacklist } =
+    useBlacklist(toggleBlacklistModalOpen);
 
   return (
     <St.Card className={GTM_CLASS_NAME.cardSwipe}>
@@ -31,7 +34,7 @@ const Card = (props: LoginCheckProps) => {
           <TagsSlider tags={tags} />
         </St.TagsWrapper>
       </St.Container>
-      <CardMenu {...props} toggleMenuModal={toggleMenuModal} />
+      <CardMenu {...props} toggleMenuModal={toggleMenuModal} openLoginModalHandler={toggleBookmarkModalOpen} />
 
       {getIsBlacklist(_id) && (
         <St.BlockCardWrapper>
@@ -48,6 +51,11 @@ const Card = (props: LoginCheckProps) => {
           handleClickAddBlacklist={handleClickAddBlacklist}
           handleClickCancelBlacklist={handleClickCancelBlacklist}
         />
+      )}
+
+      {isBookmarkModalOpen && <LoginModal closeHandler={toggleBookmarkModalOpen} contents={"북마크 기능을"} />}
+      {isBlacklistModalOpen && (
+        <LoginModal closeHandler={toggleBlacklistModalOpen} contents={"주제 다시 안보기 기능을"} />
       )}
     </St.Card>
   );

--- a/src/@components/CardCollectionPage/Card/index.tsx
+++ b/src/@components/CardCollectionPage/Card/index.tsx
@@ -34,7 +34,7 @@ const Card = (props: LoginCheckProps) => {
           <TagsSlider tags={tags} />
         </St.TagsWrapper>
       </St.Container>
-      <CardMenu {...props} toggleMenuModal={toggleMenuModal} openLoginModalHandler={toggleBookmarkModalOpen} />
+      <CardMenu {...props} toggleMenuModal={toggleMenuModal} onClickLogoutBookmark={toggleBookmarkModalOpen} />
 
       {getIsBlacklist(_id) && (
         <St.BlockCardWrapper>

--- a/src/@components/CardCollectionPage/CardSlider/index.tsx
+++ b/src/@components/CardCollectionPage/CardSlider/index.tsx
@@ -6,18 +6,16 @@ import { CardList } from "../../../types/cardCollection";
 import { externalLinks } from "../../../util/const/externalLinks";
 import Card from "../Card";
 import LastCard from "../Card/LastCard";
-import useBlacklist from "../hooks/useBlacklist";
 import useCardSwiper from "../hooks/useCardSwiper";
 import * as St from "./style";
 
 interface CardSliderProps {
-  openLoginModalHandler: () => void;
   cardLists: CardList[];
   lastCardObsvRef: React.RefObject<HTMLDivElement>;
 }
 
 const CardSlider = (props: CardSliderProps) => {
-  const { openLoginModalHandler, cardLists, lastCardObsvRef } = props;
+  const { cardLists, lastCardObsvRef } = props;
   const { swiperSettings, swiperRef, autoSlide } = useCardSwiper();
 
   return (
@@ -25,7 +23,7 @@ const CardSlider = (props: CardSliderProps) => {
       <Swiper {...swiperSettings} ref={swiperRef}>
         {cardLists.map((cardList) => (
           <SwiperSlide key={cardList._id}>
-            <Card autoSlide={autoSlide} openLoginModalHandler={openLoginModalHandler} {...cardList} />
+            <Card autoSlide={autoSlide} {...cardList} />
           </SwiperSlide>
         ))}
         <SwiperSlide>

--- a/src/@components/CardCollectionPage/index.tsx
+++ b/src/@components/CardCollectionPage/index.tsx
@@ -35,7 +35,6 @@ function CardCollectionContent() {
   const { isVisibleCTAButton, intersectionObserverRef: lastCardObsvRef } = useCTAFilter();
 
   const { isModalOpen: isFilterModalOpen, toggleModal: toggleFilterModal } = useModal();
-  const { isModalOpen: isLoginModalOpen, toggleModal: toggleLoginModal } = useModal();
 
   const { isOpened: isCoachMarkOpen, handleCloseCoachMark: toggleCoachMark } = useCoachMark();
 
@@ -45,7 +44,7 @@ function CardCollectionContent() {
     <St.MainPage>
       {isSliderDown ? <HeaderMinVer /> : <Header />}
 
-      <CardSlider openLoginModalHandler={toggleLoginModal} cardLists={cardLists} lastCardObsvRef={lastCardObsvRef} />
+      <CardSlider cardLists={cardLists} lastCardObsvRef={lastCardObsvRef} />
 
       {isVisibleCTAButton && (
         <HeadlessCTAButton
@@ -57,7 +56,6 @@ function CardCollectionContent() {
         </HeadlessCTAButton>
       )}
       {isCoachMarkOpen && <CoachMark closeHandler={toggleCoachMark} />}
-      {isLoginModalOpen && <LoginModal closeHandler={toggleLoginModal} contents={"북마크 기능인 마이피클을"} />}
       {isFilterModalOpen && (
         <FilterModal closeHandler={toggleFilterModal} fetchCardListsWithFilter={fetchCardListsWithFilter} />
       )}

--- a/src/@components/MainPage/Banner/index.tsx
+++ b/src/@components/MainPage/Banner/index.tsx
@@ -60,12 +60,6 @@ export default function Banner() {
             </SwiperSlide>
           ))}
         </Swiper>
-
-        <St.ContentsPages>
-          <St.CurrentPage>
-            {currentSlide + 1} / {newBannerImages.length}
-          </St.CurrentPage>
-        </St.ContentsPages>
       </St.BannerSlider>
       <St.PagingWrapper>
         {newBanners.map((banner, idx) => (

--- a/src/@components/MainPage/Banner/style.ts
+++ b/src/@components/MainPage/Banner/style.ts
@@ -13,29 +13,6 @@ export const BannerSlider = styled.section`
   cursor: pointer;
 `;
 
-export const ContentsPages = styled.div`
-  position: absolute;
-  right: 0;
-  bottom: 0;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.8rem;
-
-  width: 4.8rem;
-  height: 2.4rem;
-
-  background: rgba(0, 0, 0, 0.5);
-
-  z-index: 10;
-`;
-
-export const CurrentPage = styled.span`
-  ${({ theme }) => theme.newFonts.caption1};
-  color: ${({ theme }) => theme.newColors.white};
-`;
-
 export const PagingWrapper = styled.div`
   display: flex;
   justify-content: center;


### PR DESCRIPTION
<!-- ✅ PR check list -->

- [x] 브랜치명, 브랜치 알맞게 설정
- [x] Reviewer, Assignees, Label, Milestone, Issue(PR 작성 후에) 붙이기
- [ ] PR이 승인된 경우 해당 브랜치는 삭제하기

## 📌 내용
<!-- 작업한 내용 + 걸린 시간 -->
<!-- PR은 리뷰어를 위한 개발문서입니다 ! 보다 더 상세하게 적어봐요!! -->
### 로그인 모달 관련 QA 반영

- 로그인 모달을 제어하는 `useModal`의 선언 위치를 `CardCollectionPage`에서 그 내부인 `Card`로 변경했습니다.
- "북마크 기능을"과 "주제 다시 안보기 기능을" 텍스트를 따로 전달하기 위해 두개의 `LoginModal`을 선언하였습니다.
<img width="360" alt="image" src="https://github.com/TeamPiickle/client/assets/65955748/78fcfd59-77e4-402b-9cbe-bf2bf32b34cb">

<img width="360" alt="image" src="https://github.com/TeamPiickle/client/assets/65955748/02accd56-6612-441f-8733-4a2a7138add6">

<br />